### PR TITLE
Update for rendering cpuUsage in Diagnostics menu

### DIFF
--- a/Extensions/Diagnostics/Diagnostics/Diagnostics.cs
+++ b/Extensions/Diagnostics/Diagnostics/Diagnostics.cs
@@ -11,6 +11,7 @@ using System.Net.Sockets;
 using TcHmiSrv.Core;
 using TcHmiSrv.Core.General;
 using TcHmiSrv.Core.Listeners;
+using TcHmiSrv.Core.Extensions;
 using TcHmiSrv.Core.Tools.Management;
 
 namespace Diagnostics
@@ -31,13 +32,16 @@ namespace Diagnostics
             return ErrorValue.HMI_SUCCESS;
         }
 
-        private Value CollectDiagnosticsData()
+        private Value CollectDiagnosticsData(Command command)
         {
-            return new Value
+            var diagObject = new Value
             {
-                { "cpuUsage", _cpuUsage.NextValue() },
+                { "cpuUsage", Math.Truncate(_cpuUsage.NextValue()) },
                 { "sinceStartup", DateTime.Now - _startup }
             };
+
+            // ResolveBy allows subsymbols of objects to be accessed directly
+            return diagObject.ResolveBy(command.Path);
         }
 
         public void OnRequest(object sender, TcHmiSrv.Core.Listeners.RequestListenerEventArgs.OnRequestEventArgs e)
@@ -52,7 +56,7 @@ namespace Diagnostics
                         case "Diagnostics":
                             {
                             command.ExtensionResult = Convert.ToUInt32(ExtensionSpecificError.SUCCESS);
-                            command.ReadValue = CollectDiagnosticsData();
+                            command.ReadValue = CollectDiagnosticsData(command);
                             }
                             break;
                     }

--- a/Extensions/Diagnostics/Diagnostics/config/Diagnostics.Config.json
+++ b/Extensions/Diagnostics/Diagnostics/config/Diagnostics.Config.json
@@ -2,7 +2,7 @@
   "$schema": "ExtensionSettings.Schema.json",
   "guid": "12dbbc08-9199-433c-b668-bb073e81b3f1",
   "version": "1.0.0.0",
-  "configVersion": "1.0.0.1",
+  "configVersion": "1.0.0.13",
   "configSchemaHash": "",
   "policies": [
     "StrictPropertyValidation"
@@ -17,16 +17,9 @@
         "type": "object",
         "properties": {
           "cpuUsage": {
-            "allOf": [
-              {
-                "$ref": "tchmi:general#/definitions/FLOAT"
-              },
-              {
-                "readOnly": true,
-                "propertyOrder": 1,
-                "displayClass": "%"
-              }
-            ]
+            "type": "number",
+            "readOnly": true,
+            "propertyOrder": 1
           },
           "sinceStartup": {
             "propertyOrder": 2,

--- a/Extensions/Diagnostics/Diagnostics/config/Diagnostics.Language.en.json
+++ b/Extensions/Diagnostics/Diagnostics/config/Diagnostics.Language.en.json
@@ -3,6 +3,7 @@
   "locale": "en",
   "localizedText": {
     "cpuUsage": "CPU usage",
+    "TOOLTIP_cpuUsage": "Unit: %",
     "sinceStartup": "Since extension initialization"
   }
 }


### PR DESCRIPTION
Testing done in VS2019 and TcHmi 1.12.748.0. 

Current Diagnostics sample extension does not render cpuUsage in the diagnostics menu. FLOAT points to REAL32, which points to "anyOf". The config / diag menu generates a drop down for "anyOf" types for the user to choose the type. 

![image](https://user-images.githubusercontent.com/66790612/131619728-7cedf9c6-d0e8-4d54-a528-1dec7370fa40.png)

Since this is a read only number, changing the schema to number only allows rendering. This new schema allows rendering. The schema property displayClass : "%" has no effect. The "%" sign does not render in the config menu. Moving it to a tooltip allows a unit tooltip to show more info. 

Truncating the CPU usage return provides an easier to read whole percentage.

![image](https://user-images.githubusercontent.com/66790612/131619771-330363ea-eedf-4b23-b20c-400dfca8e088.png)


Adding the ResolveBy method allows :: subSymbol access. Users can then bind to only cpuUsage or only sinceStartup for use in control bindings. 