### PR TITLE
RandomValue: Changed GetConfigValue 'MaxRandom' to 'maxRandom'

### DIFF
--- a/Extensions/RandomValue/RandomValue/RandomValue.cs
+++ b/Extensions/RandomValue/RandomValue/RandomValue.cs
@@ -29,7 +29,7 @@ namespace RandomValue
             {
                 // initialize data from configuration
                 // this can not be done before Init, because the properties of TcHmiApplication are initialized just before 
-                data = new Data(TcHmiApplication.AsyncHost.GetConfigValue(TcHmiApplication.Context, "MaxRandom"));
+                data = new Data(TcHmiApplication.AsyncHost.GetConfigValue(TcHmiApplication.Context, "maxRandom"));
 
                 // add event handlers
                 this.requestListener.OnRequest += this.OnRequest;


### PR DESCRIPTION
The extension schema has the entry 'maxRandom' for the maximum random number config item. The GetConfigValue within the server extension init requests the value 'MaxRandom'. In testing, this returns a value of 0 since 'MaxRandom' is not found to match the config entry of 'maxRandom' in the schema file. 

The new async debugger in API 1.5.0.0 shows this behavior. BGetConfigValue documentation indicates an unknown match should return null. Instead, it returns 0. It is unclear if the Value assignment converts null to 0 with a cast, or if GetConfigValue itself returns 0.

Current call and return value. According to GetConfigValue documentation, this should return null:

![image](https://user-images.githubusercontent.com/66790612/168632450-045bc702-c288-4012-9e6b-64a894b49dde.png)

![image](https://user-images.githubusercontent.com/66790612/168631535-a3117a97-3023-4f5e-8489-3888ed59d2c1.png)

![image](https://user-images.githubusercontent.com/66790612/168632126-da1b3a4b-8375-4022-8d95-2bab56b4eafe.png)



Changing string to exactly match 'maxRandom':

![image](https://user-images.githubusercontent.com/66790612/168631701-ac14704c-f750-4970-b3f8-8dae339a7a8f.png)
